### PR TITLE
Add a caching fro PreparedStatement  since cassandra java driver is detecting performance issue

### DIFF
--- a/src/main/java/com/contrastsecurity/cassandra/migration/utils/CachePrepareStatement.java
+++ b/src/main/java/com/contrastsecurity/cassandra/migration/utils/CachePrepareStatement.java
@@ -1,0 +1,25 @@
+package com.contrastsecurity.cassandra.migration.utils;
+
+import java.util.concurrent.ConcurrentHashMap;
+
+import com.datastax.driver.core.PreparedStatement;
+import com.datastax.driver.core.Session;
+
+public class CachePrepareStatement {
+	private ConcurrentHashMap<Integer, PreparedStatement> cacheStatement = new ConcurrentHashMap<>();
+
+	private Session session;
+
+	public CachePrepareStatement(Session session) {
+		this.session = session;
+	}
+
+	public PreparedStatement prepare(String s){
+		PreparedStatement ps = cacheStatement.get(s.hashCode());
+		if(ps == null){
+			ps = session.prepare(s);
+			cacheStatement.put(s.hashCode(), ps);
+		}
+		return ps;
+	}
+}


### PR DESCRIPTION
Since i was running migration i was getting this error message

```
Re-preparing already prepared query . Please note that preparing the same query more than once is generally an anti-pattern and will likely affect performance. Consider preparing the statement only once.
```

http://stackoverflow.com/questions/22915840/re-using-preparedstatement-when-using-datastax-cassandra-driver
