### PR TITLE
Patch to support SSL-enabled client-to-node connections

### DIFF
--- a/src/main/java/com/contrastsecurity/cassandra/migration/CassandraMigration.java
+++ b/src/main/java/com/contrastsecurity/cassandra/migration/CassandraMigration.java
@@ -152,6 +152,8 @@ public class CassandraMigration {
                     throw new IllegalArgumentException("Password must be provided with username.");
                 }
             }
+            if (keyspace.getCluster().isSSL())
+                builder.withSSL();
             cluster = builder.build();
 
             Metadata metadata = cluster.getMetadata();

--- a/src/main/java/com/contrastsecurity/cassandra/migration/config/Cluster.java
+++ b/src/main/java/com/contrastsecurity/cassandra/migration/config/Cluster.java
@@ -7,7 +7,8 @@ public class Cluster {
         CONTACTPOINTS(PROPERTY_PREFIX + "contactpoints", "Comma separated values of node IP addresses"),
         PORT(PROPERTY_PREFIX + "port", "CQL native transport port"),
         USERNAME(PROPERTY_PREFIX + "username", "Username for password authenticator"),
-        PASSWORD(PROPERTY_PREFIX + "password", "Password for password authenticator");
+        PASSWORD(PROPERTY_PREFIX + "password", "Password for password authenticator"),
+        SSL(PROPERTY_PREFIX + "ssl", "Cluster requires SSL connection (true/false)");
 
         private String name;
         private String description;
@@ -30,6 +31,7 @@ public class Cluster {
     private int port = 9042;
     private String username;
     private String password;
+    private boolean ssl;
 
     public Cluster() {
         String contactpointsP = System.getProperty(ClusterProperty.CONTACTPOINTS.getName());
@@ -47,6 +49,8 @@ public class Cluster {
         String passwordP = System.getProperty(ClusterProperty.PASSWORD.getName());
         if (null != passwordP && passwordP.trim().length() != 0)
             this.password = passwordP;
+
+        this.ssl = Boolean.getBoolean(ClusterProperty.SSL.getName());
     }
 
     public String[] getContactpoints() {
@@ -79,5 +83,13 @@ public class Cluster {
 
     public void setPassword(String password) {
         this.password = password;
+    }
+
+    public boolean isSSL() {
+        return ssl;
+    }
+
+    public void setSSL(boolean ssl) {
+        this.ssl = ssl;
     }
 }

--- a/src/test/java/com/contrastsecurity/cassandra/migration/BaseIT.java
+++ b/src/test/java/com/contrastsecurity/cassandra/migration/BaseIT.java
@@ -17,6 +17,7 @@ public abstract class BaseIT {
     public static final int CASSANDRA_PORT = 9147;
     public static final String CASSANDRA_USERNAME = "cassandra";
     public static final String CASSANDRA_PASSWORD = "cassandra";
+    public static final boolean CASSANDRA_SSL = false;
 
     private Session session;
 
@@ -57,6 +58,7 @@ public abstract class BaseIT {
         ks.getCluster().setPort(CASSANDRA_PORT);
         ks.getCluster().setUsername(CASSANDRA_USERNAME);
         ks.getCluster().setPassword(CASSANDRA_PASSWORD);
+        ks.getCluster().setSSL(CASSANDRA_SSL);
         return ks;
     }
 
@@ -67,6 +69,8 @@ public abstract class BaseIT {
         com.datastax.driver.core.Cluster.Builder builder = new com.datastax.driver.core.Cluster.Builder();
         builder.addContactPoints(CASSANDRA_CONTACT_POINT).withPort(CASSANDRA_PORT);
         builder.withCredentials(keyspace.getCluster().getUsername(), keyspace.getCluster().getPassword());
+        if (keyspace.getCluster().isSSL())
+            builder.withSSL();
         Cluster cluster = builder.build();
         session = cluster.connect();
         return session;


### PR DESCRIPTION
Simple patch to support SSL between the client and the Cassandra cluster