### PR TITLE
[fix-ranking] Fix for calculateInstalledRank query

### DIFF
--- a/src/main/java/com/contrastsecurity/cassandra/migration/dao/SchemaVersionDAO.java
+++ b/src/main/java/com/contrastsecurity/cassandra/migration/dao/SchemaVersionDAO.java
@@ -203,7 +203,7 @@ public class SchemaVersionDAO {
         Statement statement = new SimpleStatement(
                 "UPDATE " + keyspace.getName() + "." + tableName + COUNTS_TABLE_NAME_SUFFIX +
                         " SET count = count + 1" +
-                        "WHERE name = 'installed_rank';");
+                        " WHERE name = 'installed_rank';");
         session.execute(statement);
         Select select = QueryBuilder
                 .select("count")


### PR DESCRIPTION
Avoids the following error during migrations:

```java
TRACE [Native-Transport-Requests-1] 2017-06-02 08:14:19,284 Message.java:516 - Received: QUERY UPDATE eagles_nest.cassandra_migration_version_counts SET count = count + 1WHERE name = 'installed_rank';[pageSize = 5000], v=4/v4
TRACE [Native-Transport-Requests-1] 2017-06-02 08:14:19,285 Tracing.java:188 - request complete
TRACE [Native-Transport-Requests-1] 2017-06-02 08:14:19,285 Message.java:535 - Responding: ERROR SYNTAX_ERROR: line 1:76 mismatched input 'HERE' expecting K_WHERE (... count = count + 1W[HERE]...), v=4/v4
```